### PR TITLE
Fixed dash, and PlayerNote functions

### DIFF
--- a/src/scenes/player0.tscn
+++ b/src/scenes/player0.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=13 format=3 uid="uid://c6al2btloohgx"]
+[gd_scene load_steps=14 format=3 uid="uid://c6al2btloohgx"]
 
 [ext_resource type="Script" uid="uid://dgvhs8c8jo1at" path="res://scripts/player/player.gd" id="1_iq3ln"]
 [ext_resource type="Script" uid="uid://bd5bvp40wvxeh" path="res://scripts/player/player_state_machine.gd" id="2_tv4ow"]
 [ext_resource type="Script" uid="uid://1yhfapoar26s" path="res://scripts/player/states/state_idle.gd" id="3_hxbjb"]
 [ext_resource type="Script" uid="uid://bgdd0pksxmi0b" path="res://scripts/player/states/state_walk.gd" id="4_ads5b"]
 [ext_resource type="Script" uid="uid://y18fdptngycp" path="res://scripts/player/states/state_dash.gd" id="5_60uw5"]
+[ext_resource type="Script" uid="uid://ukqkfd7la4xl" path="res://scripts/metronome/music_notation/notes/player_note.gd" id="6_iq3ln"]
 [ext_resource type="Script" uid="uid://dwyixca3o82d1" path="res://scripts/metronome/music_notation/notes/qtr_note.gd" id="6_sf4gc"]
 [ext_resource type="Texture2D" uid="uid://b66pulo52gho8" path="res://assets/player/TempPlayer.png" id="7_3wdol"]
 [ext_resource type="Script" uid="uid://lgu40v7o00f2" path="res://scripts/components/health_component.gd" id="10_oek5m"]
@@ -44,8 +45,14 @@ move_speed = 275.0
 
 [node name="Dash" type="Node" parent="StateMachine"]
 script = ExtResource("5_60uw5")
+initial_speed = null
+dash_length = null
 
-[node name="QuarterNote" type="Node" parent="StateMachine/Dash"]
+[node name="PlayerNote" type="Node" parent="StateMachine/Dash"]
+script = ExtResource("6_iq3ln")
+metadata/_custom_type_script = "uid://ukqkfd7la4xl"
+
+[node name="QuarterNote" type="Node" parent="StateMachine/Dash/PlayerNote"]
 script = ExtResource("6_sf4gc")
 
 [node name="PlayerSprite" type="AnimatedSprite2D" parent="."]

--- a/src/scripts/metronome/metronome.gd
+++ b/src/scripts/metronome/metronome.gd
@@ -34,10 +34,13 @@ func setAttributesName(att_name : String) -> void:
 func activateNotifier() -> void:
 	notifier.bpm = attributes.bpm
 
-	var b = notifier.beats(1)
-	b.connect(func(count): print("Hello from note %d!" % (count)))
+	#var b = notifier.beats(1)
+	#b.connect(func(count): print("Hello from note %d!" % (count)))
 	var a = notifier.beats(1)
-	a.connect(func(count): emit_signal("beat_occured"))
+	a.connect(func(count): 
+		emit_signal("beat_occured")
+		print("Hello from note %d!" % (count))
+		)
 	notifier.beats(attributes.time_signature.top).connect(func(count): print("Hello from measure %d!" % (count)))
 	notifier.running = true
 	
@@ -47,5 +50,5 @@ func getNoteLength() -> float:
 	return notifier.beat_length
 	
 func get_rhythm(interval: float, offset: float = 0.0, once: bool = false) -> Signal:
-	return notifier.beats(interval, once, offset)
+	return notifier.beats(interval, !once, offset)
 	

--- a/src/scripts/metronome/music_notation/notes/player_note.gd
+++ b/src/scripts/metronome/music_notation/notes/player_note.gd
@@ -7,6 +7,7 @@ var note : BaseNote
 #var playable_on : Notes = Notes.EIGHTH_NOTE
 var playable_on : BaseNote
 var offset : float
+var _time_since_last_note : float
 
 
 #value from 0 to 10 determining the ranges at which something is considered a hit or not
@@ -21,6 +22,14 @@ enum Note_Score {PERFECT, GOOD, BAD, MISS}
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	set_process(true)
+	_time_since_last_note = 99999
+	print(perfect_range)
+	print(good_range)
+	print(bad_range)
+	#TODO: rework this temp fix
+	note = get_child(0)
+	playable_on = get_child(0)
 	pass # Replace with function body.
 	
 #TODO, calculate note rating depending on how close to how off the input is from the beat/playable beat
@@ -37,6 +46,16 @@ func give_note_rating() -> Note_Score:
 		return Note_Score.BAD
 	print("miss")
 	return Note_Score.MISS
+	
+	
+func _process(delta: float) -> void:
+	_time_since_last_note += delta
+	pass
+
+func on_note_triggered(note: BaseNote,count: int) -> void:
+	print("PlayerNoteTriggered")
+	_time_since_last_note = 0
+	pass
 
 # TODO, if the bpm is too high, the ranges might go outside the beat timings
 # at least make it so that they have to be within the range of the beat
@@ -45,29 +64,16 @@ func _recalculate_ranges() -> void:
 	
 # TODO, get the absolute distance from a playable note. Only positive values, no negative
 func _error_from_valid_note() -> float:
+	print("Error check on", self, "time =", _time_since_last_note)
 	var bottom_time_sig: int = Conductor.getAttributes().time_signature.bottom
-	#var tsb : float = #note.time_since_beat
-	var tsb: float = playable_on._internal_timer
-	
-	#var beat_length = note.get_beat_duration()
 	
 	var note_length : float = playable_on.get_beat_duration()
+	
 	var error_diffs : Array[float] = [
-		tsb,
-		note_length - tsb
+		_time_since_last_note,
+		abs(note_length - _time_since_last_note)
 	]
-	#Case for when playable_on <= note
 	
-	
-	'''
-	#calculates the difference between notes and the playable timings
-	var npb : float = playable_on.notes_per_beat #how many notes per beat
-	var note_length : float = playable_on.get_beat_duration()
-	for i in range(0, npb + 1):
-		error_diffs.append(abs((note_length * i) - tsb))
-		
-	#TODO case for when playable_on > note
-	'''
 	print(error_diffs.min())
 	
 	return error_diffs.min()

--- a/src/scripts/player/states/state_dash.gd
+++ b/src/scripts/player/states/state_dash.gd
@@ -3,8 +3,8 @@ class_name State_Dash extends State
 @onready var walk : State = $"../Walk"
 @onready var idle : State = $"../Idle"
 
-var note : QuarterNote
-var our_note : PlayerNote
+@onready var note : QuarterNote = $"PlayerNote/QuarterNote"
+@onready var our_note : PlayerNote = $"PlayerNote"
 
 var internal_dash_timer : float = 0.0
 
@@ -20,10 +20,6 @@ var dash_duration : float = 0.2
 var on_cooldown : bool = false
 
 func _ready() -> void:
-	note = QuarterNote.new()
-	our_note = PlayerNote.new()
-	our_note.playable_on = note
-	our_note.note = note
 	pass
 
 # When player enters state
@@ -35,7 +31,7 @@ func Enter() -> void:
 	initial_position = player.position
 	player.velocity = dash_direction * initial_speed
 	
-	print("Dash")
+	#print("Dash")
 	
 	#keep track of how long ability goes on cooldown for
 	on_cooldown = true

--- a/src/scripts/player/states/state_idle.gd
+++ b/src/scripts/player/states/state_idle.gd
@@ -6,7 +6,7 @@ class_name State_Idle extends State
 # When player enters state
 func Enter() -> void:
 	#player.UpdateAnimation("idle")
-	print("idle")
+	#print("idle")
 	pass
 	
 # When player enters state

--- a/src/scripts/player/states/state_walk.gd
+++ b/src/scripts/player/states/state_walk.gd
@@ -7,7 +7,7 @@ class_name State_Walk extends State
 # When player enters state
 func Enter() -> void:
 	#player.UpdateAnimation("walking")
-	print("walk")
+	#print("walk")
 	pass
 	
 # When player enters state


### PR DESCRIPTION
Fixed a bug in Metronome that made all the signals "oneshot" instead of being a repeated signal.

PlayerNote hit detection has been implemented, which compares the timing of when an ability (like dash) is pressed compared to the beat, and returns a Rating dependent on that beat.
The strictness of the window is dependent on a value called OverallDifficulty, which goes from 0 to 10.

For now, set it to like 6.5

Have a temporary implementation of Dash that allows it to work properly. Will rework it in the future to be more expandable.


